### PR TITLE
Fix multi monitor stops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,6 @@ update: ## Pull master from custom-components/wienerlinien
 homeassistant-install: ## Install the latest dev version of Home Assistant
 	python3 -m pip --disable-pip-version-check install -U setuptools wheel
 	python3 -m pip --disable-pip-version-check \
-		install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev;
+		install --upgrade git+https://github.com/home-assistant/home-assistant.git@dev;
 
 homeassistant-update: homeassistant-install ## Alias for 'homeassistant-install'

--- a/custom_components/wienerlinien/__init__.py
+++ b/custom_components/wienerlinien/__init__.py
@@ -1,5 +1,5 @@
 """
-Home Assistant integration to get information about departures from a specified Wiener Linien stop. 
+Home Assistant integration to get information about departures from a specified Wiener Linien stop.
 
-https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien/
+https://github.com/jozefKruszynski/home-assistant-wienerlinien/
 """

--- a/custom_components/wienerlinien/__init__.py
+++ b/custom_components/wienerlinien/__init__.py
@@ -1,5 +1,5 @@
 """
 Home Assistant integration to get information about departures from a specified Wiener Linien stop.
 
-https://github.com/jozefKruszynski/home-assistant-wienerlinien/
+https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien/
 """

--- a/custom_components/wienerlinien/manifest.json
+++ b/custom_components/wienerlinien/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "wienerlinien",
   "name": "Wienerlinien",
-  "version": "1.0.0",
-  "documentation": "https://github.com/jozefKruszynski/home-assistant-wienerlinien",
-  "issue_tracker": "https://github.com/jozefKruszynski/home-assistant-wienerlinien/issues",
+  "version": "1.2.0",
+  "documentation": "https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien",
+  "issue_tracker": "https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien/issues",
   "dependencies": [],
   "codeowners": [
-    "@jozefKruszynski"
+    "@tofuSCHNITZEL"
   ],
   "requirements": [],
   "iot_class": "cloud_polling"

--- a/custom_components/wienerlinien/manifest.json
+++ b/custom_components/wienerlinien/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "wienerlinien",
   "name": "Wienerlinien",
-  "version": "1.2.0",
-  "documentation": "https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien",
-  "issue_tracker": "https://github.com/tofuSCHNITZEL/home-assistant-wienerlinien/issues",
+  "version": "1.0.0",
+  "documentation": "https://github.com/jozefKruszynski/home-assistant-wienerlinien",
+  "issue_tracker": "https://github.com/jozefKruszynski/home-assistant-wienerlinien/issues",
   "dependencies": [],
   "codeowners": [
-    "@tofuSCHNITZEL"
+    "@jozefKruszynski"
   ],
   "requirements": [],
   "iot_class": "cloud_polling"

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
     "name": "wienerlinien",
     "render_readme": true,
-    "hacs": "0.19.0",
     "homeassistant": "2022.3.1",
     "country": "AT"
 }


### PR DESCRIPTION
I changed quite a few things here, and Python is not my weapon of choice in the past, hopefully I didn't mess anything up.

I modified the code to allow multiple monitors to be extracted from a single stopID

I changed the naming of the entities created to something that I liked, feels sensible, obviously open to change.

I also assign each entity a uniqueId. When adding the same stop id numerous times, I found that I had issues with the uniqueID, but I fixed it in a way that works, but is not super elegant, and might not be the best solution in Python, not my language usually.

I also question whether the same stop id should be allowed to entered twice??

Already had an idea to improve the code further, but wanted to send you a pull request for what I have so far.

My idea, would be that we register a Device, and add each stop as an entity of the device, should give more of a nice overview in the home assistant UI then.